### PR TITLE
Plus de contrôle sur la largeur des tableaux

### DIFF
--- a/frontend/src/mycStyle.css
+++ b/frontend/src/mycStyle.css
@@ -595,6 +595,7 @@ input.cellError {
         border-collapse: collapse; 
         border-spacing: 0; /* ← this is cellspacing */
         overflow: hidden;
+        table-layout: fixed;
         /* the following is to switch to an auto col width layout : */
             /* width: 100%;
             table-layout: fixed; */
@@ -609,7 +610,7 @@ input.cellError {
         border-color: var(--table-border-color);
     }
     table.table tr td {
-        line-height: 0;
+        line-height: 26px;
         font-size: var(--t-fs-p2);
     }
     table.table tr td > * {
@@ -619,15 +620,14 @@ input.cellError {
     /* table/cell */
         table.table tr td,
         table.table tr th {
-            min-width: calc(3.7rem * 1); /* temporary fix for modulo cell sizing */
-            max-width: calc(3.7rem * 4); /* temporary fix for modulo cell sizing */
+            /* min-width: calc(3.7rem * 1); /* temporary fix for modulo cell sizing */
+            /* max-width: calc(3.7rem * 4); /* temporary fix for modulo cell sizing */
             height: 3.7rem !important; /* temporary fix for modulo cell sizing */
             padding: var(--table-cell-padding) !important;
             font-family: var(--t-ff-p-mono);
             font-weight: var(--t-fw-p-mono-bold);
-            white-space: nowrap;
+            /* white-space: nowrap; */
             overflow: hidden;
-            text-overflow: ellipsis;
             vertical-align: middle;
             color: var(--c-h0-s0-l3);
         }
@@ -672,7 +672,24 @@ input.cellError {
             table.table .hstack {
                 gap: 0rem !important; /* managing this with badge margins instead */ 
             }
-
+    .tablecolfluid {
+        width: 100%;
+    }
+    .tablecol1 {
+        width: calc(3.7rem * 1);
+    }
+    .tablecol2 {
+        width: calc(3.7rem * 2);
+    }
+    .tablecol3 {
+        width: calc(3.7rem * 3);
+    }
+    .tablecol4 {
+        width: calc(3.7rem * 4);
+    }
+    .tablecol5 {
+        width: calc(3.7rem * 5);
+    }
 
 
 /* "item" elements —————————————————————*/

--- a/frontend/src/pages/Inventory/InventoryStep1.tsx
+++ b/frontend/src/pages/Inventory/InventoryStep1.tsx
@@ -260,6 +260,12 @@ export default function InventoryStep1(){
                     </div>
                 </DescAndNav>
                 <Table bordered>
+                    <colgroup>
+                        <col className="tablecol5" /> {/* Vehicle */}
+                        <col className="tablecol2" /> {/* Network */}
+                        <col className="tablecol4" /> {/* Type */}
+                        <col className="tablecolfluid" /> {/* Fuels */}
+                    </colgroup>
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Transport modes, current and expected"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Vehicle</span></span></ItemWithOverlay></th>
@@ -282,12 +288,11 @@ export default function InventoryStep1(){
                                 <td>{networkBadge}</td>
                                 <td>{typeBadge}</td>
                                 <td>
-                                    <Stack direction="horizontal" gap={2}>
-                                        {Object.keys(vehicle.fuels).map((ftype, index) => (
-                                            <Badge key={index} bg="info" onClick={e=>removeFuel(vtype, ftype as FuelType)}><span className="item"><span>{ftype}</span><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#times"}/></svg></span></Badge>
-                                        ))}
-                                        <Button size="sm" variant="action" onClick={e => fuelTrigger(vtype)}><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#plus"}/></svg></span></Button>
-                                    </Stack>
+                                    {Object.keys(vehicle.fuels).map((ftype, index) => (
+                                        <Badge key={index} bg="info" onClick={e=>removeFuel(vtype, ftype as FuelType)}><span className="item"><span>{ftype}</span><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#times"}/></svg></span></Badge>
+                                    ))}
+                                    <Button size="sm" variant="action" onClick={e => fuelTrigger(vtype)}><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#plus"}/></svg></span></Button>
+                                    
                                 </td>
                             </tr>)
                         })}

--- a/frontend/src/pages/Inventory/InventoryStep2.tsx
+++ b/frontend/src/pages/Inventory/InventoryStep2.tsx
@@ -242,6 +242,26 @@ export default function InventoryStep2(){
                 </DescAndNav>
                 <ApproachSelector></ApproachSelector>
                 <Table bordered>
+                    {computationApproach === "fleet" 
+                        ? <colgroup>
+                            <col className="tablecol3" /> {/* Vehicule */}
+                            <col className="tablecol2" /> {/* Fuels */}
+                            <col className="tablecol1" /> {/* Src */}
+                            <col className="tablecolfluid" /> {/* Vehicule stock */}
+                            <col className="tablecolfluid" /> {/* Avg mileage */}
+                            <col className="tablecol3" /> {/* Computed VKT */}
+                            <col className="tablecol1" /> {/* Src */}
+                            <col className="tablecol2" /> {/* VKT% */}
+                        </colgroup>
+                        : <colgroup>
+                            <col className="tablecol4" /> {/* Vehicule */}
+                            <col className="tablecol3" /> {/* Fuels */}
+                            <col className="tablecol1" /> {/* Src */}
+                            <col className="tablecolfluid" /> {/* VKT Input */}
+                            <col className="tablecol1" /> {/* Src */}
+                            <col className="tablecol2" /> {/* VKT% */}
+                        </colgroup>
+                    }
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Transport modes, current and expected"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Vehicle</span></span></ItemWithOverlay></th>
@@ -311,7 +331,7 @@ export default function InventoryStep2(){
                                     {computationApproach === "fleet" && <td><Form.Control value={fleetStock} onChange={e => updateInputFleetStock(vtype, e.target.value)}></Form.Control></td>}
                                     {computationApproach === "fleet" && <td><Form.Control value={fleetMileage} onChange={e => updateInputFleetMileage(vtype, e.target.value)}></Form.Control></td>}
                                     {computationApproach === "vkt" && <td><Form.Control value={vkt} onChange={e => updateInputVkt(vtype, e.target.value)}></Form.Control></td>}
-                                    {computationApproach === "fleet" && <td>{vkt}</td>}
+                                    {computationApproach === "fleet" && <OutputNumberTd value={vkt}></OutputNumberTd>}
                                     <TdDiagonalBar></TdDiagonalBar>
                                     <td className={totalPercent > 100 ? "cellError": ""}>{totalPercent || 0}</td>
                                 </tr>,

--- a/frontend/src/pages/Inventory/InventoryStep3.tsx
+++ b/frontend/src/pages/Inventory/InventoryStep3.tsx
@@ -168,6 +168,12 @@ export default function InventoryStep3(){
                     </div>
                 </DescAndNav>
                 <Table bordered>
+                    <colgroup>
+                        <col className="tablecol5" /> {/* Vehicle */}
+                        <col className="tablecol3" /> {/* Fuels */}
+                        <col className="tablecol1" /> {/* Src */}
+                        <col className="tablecolfluid" /> {/* Cons */}
+                    </colgroup>
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Transport modes, current and expected"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Vehicle</span></span></ItemWithOverlay></th>

--- a/frontend/src/pages/Inventory/InventoryStep4.tsx
+++ b/frontend/src/pages/Inventory/InventoryStep4.tsx
@@ -121,6 +121,11 @@ export default function InventoryStep4(){
                 </DescAndNav>
                 <h3>Electricity</h3>
                 <Table bordered>
+                    <colgroup>
+                        <col className="tablecol5" /> {/* Network */}
+                        <col className="tablecol1" /> {/* Src */}
+                        <col className="tablecolfluid" /> {/* Emissions Input */}
+                    </colgroup>
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Emissions related to energy production can differ if the energy is used in road or rail"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Network</span></span></ItemWithOverlay></th>
@@ -147,6 +152,11 @@ export default function InventoryStep4(){
                 </Table>
                 <h3>Hydrogen</h3>
                 <Table bordered>
+                    <colgroup>
+                        <col className="tablecol5" /> {/* Network */}
+                        <col className="tablecol1" /> {/* Src */}
+                        <col className="tablecolfluid" /> {/* Emissions Input */}
+                    </colgroup>
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Emissions related to energy production can differ if the energy is used in road or rail"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Network</span></span></ItemWithOverlay></th>

--- a/frontend/src/pages/Inventory/InventoryStep5.tsx
+++ b/frontend/src/pages/Inventory/InventoryStep5.tsx
@@ -150,6 +150,14 @@ export default function InventoryStep5(){
                 </DescAndNav>
                 <h3>Energy balance</h3>
                 <Table bordered>
+                    <colgroup>
+                        <col className="tablecol3" /> {/* Network */}
+                        <col className="tablecol4" /> {/* Fuels */}
+                        <col className="tablecol1" /> {/* Src */}
+                        <col className="tablecolfluid" /> {/* Energy balance */}
+                        <col className="tablecol3" /> {/* Calculated */}
+                        <col className="tablecol2" /> {/* Gap */}
+                    </colgroup>
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Energy stats sources usually differ if network is road or rail"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Network</span></span></ItemWithOverlay></th>
@@ -223,6 +231,14 @@ export default function InventoryStep5(){
                 </Table>
                 <h3>Emissions</h3>
                 <Table bordered>
+                    <colgroup>
+                        <col className="tablecol3" /> {/* Network */}
+                        <col className="tablecol4" /> {/* Fuels */}
+                        <col className="tablecol1" /> {/* Src */}
+                        <col className="tablecolfluid" /> {/* Emissions */}
+                        <col className="tablecol3" /> {/* Calculated */}
+                        <col className="tablecol2" /> {/* Gap */}
+                    </colgroup>
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Energy stats sources usually differ if network is road or rail"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Network</span></span></ItemWithOverlay></th>

--- a/frontend/src/pages/Inventory/InventoryStep6.tsx
+++ b/frontend/src/pages/Inventory/InventoryStep6.tsx
@@ -130,6 +130,11 @@ export default function InventoryStep6(){
                     </div>
                 </DescAndNav>
                 <Table bordered>
+                    <colgroup>
+                        <col className="tablecol5" /> {/* Vehicle */}
+                        <col className="tablecol1" /> {/* Src */}
+                        <col className="tablecolfluid" /> {/* Load */}
+                    </colgroup>
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Transport modes, current and expected"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Vehicle</span></span></ItemWithOverlay></th>

--- a/frontend/src/pages/Inventory/InventoryStep7.tsx
+++ b/frontend/src/pages/Inventory/InventoryStep7.tsx
@@ -139,6 +139,12 @@ export default function InventoryStep7(){
                 <TTWorWTWSelector ttwOrWtw={ttwOrWtw} setTtwOrWtw={setTtwOrWtw}></TTWorWTWSelector>
                 <h3>GHG emissions</h3>
                 <Table bordered>
+                    <colgroup>
+                        <col className="tablecol5" /> {/* Vehicle */}
+                        <col className="tablecol3" /> {/* Fuels */}
+                        <col className="tablecolfluid" /> {/* Emissions Factor */}
+                        <col className="tablecolfluid" /> {/* GHG Emissions */}
+                    </colgroup>
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Transport modes, current and expected"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Vehicle</span></span></ItemWithOverlay></th>
@@ -172,7 +178,7 @@ export default function InventoryStep7(){
                                     {i===0 && <td rowSpan={ftypes.length} style={{verticalAlign: "top"}}><Badge bg="disabled"><span className="item"><span>{vtype}</span></span></Badge></td>}
                                     <td><Badge bg="disabled"><span className="item"><span>{ftype}</span></span></Badge></td>
                                     {ftype !== "Electric" && ftype !== "Hydrogen" 
-                                        ? <td>{ges}</td>
+                                        ? <OutputNumberTd value={ges} decimals={0}></OutputNumberTd>
                                         : <TdDiagonalBar></TdDiagonalBar>
                                     }
                                     <OutputNumberTd value={co2[0]}></OutputNumberTd>

--- a/frontend/src/pages/Inventory/InventoryStep8.tsx
+++ b/frontend/src/pages/Inventory/InventoryStep8.tsx
@@ -130,6 +130,11 @@ export default function InventoryStep8(){
                     </div>
                 </DescAndNav>
                 <Table bordered>
+                    <colgroup>
+                        <col className="tablecol5" /> {/* Passenger transport */}
+                        <col className="tablecol1" /> {/* Src */}
+                        <col className="tablecolfluid" /> {/* Avg trip len */}
+                    </colgroup>
                     <thead>
                         <tr>
                             <th className="item-sm"><ItemWithOverlay overlayContent="Passenger transport modes, current and expected"><span className="item"><svg className="icon icon-size-s" viewBox="0 0 22 22"><use href={"/icons.svg#circle-info"}/></svg><span>Passenger transport</span></span></ItemWithOverlay></th>


### PR DESCRIPTION
Je propose d'utiliser `<colgroup>` pour définir manuellement les tailles des colonnes.

J'ai créé les classes suivantes:
```css
.tablecolfluid {
    width: 100%;
}
.tablecol1 {
    width: calc(3.7rem * 1);
}
.tablecol2 {
    width: calc(3.7rem * 2);
}
.tablecol3 {
    width: calc(3.7rem * 3);
}
.tablecol4 {
    width: calc(3.7rem * 4);
}
.tablecol5 {
    width: calc(3.7rem * 5);
}
 ```

`tablecol1`, `tablecol2` etc .. ont des tailles fixes, `tablecolfluid` utilise l'espace restant.

En pratique ça s'utilise comme ça (cf l'inventaire pour plus d'exemples):
```jsx
<colgroup>
    <col className="tablecol4" /> {/* Vehicule */}
    <col className="tablecol3" /> {/* Fuels */}
    <col className="tablecol1" /> {/* Src */}
    <col className="tablecolfluid" /> {/* VKT Input */}
    <col className="tablecol1" /> {/* Src */}
    <col className="tablecol2" /> {/* VKT% */}
</colgroup>
```

Ça reste serré sur les gros tableaux, mais c'est mieux qu'avant.

J'ai fait les modifs sur l'inventaire, mais il faut reproduire sur les autres scénarios.